### PR TITLE
Dev

### DIFF
--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -12,7 +12,15 @@ namespace Centrality {
 void BordersFinder::FindBorders() {
   using namespace std;
 
-  if (ranges_.size() < 2) return;
+  bool is_ranges_predefined;
+  if(ranges_.size() > 1) {
+    is_ranges_predefined = true;
+  } else if (ranges_.size() == 0) {
+    is_ranges_predefined = false;
+  } else {
+    throw std::runtime_error("BordersFinder::ranges_.size() == 1 is not a legal value");
+  }
+
   if (norm_ == -1) norm_ = histo_.Integral(0, histo_.GetNbinsX());
   if (!isSpectator_) std::reverse(std::begin(ranges_), std::end(ranges_));
 
@@ -24,15 +32,15 @@ void BordersFinder::FindBorders() {
   int n = axis->GetNbins();
 
   double* histIntegral = histo_.GetIntegral();
-  double x[n];
-  for (int i = 0; i < n; ++i) {
-    x[i] = axis->GetBinLowEdge(i + 1);
+  double* x = new double[n+1];
+  for (int i = 0; i <= n; ++i) {
+    x[i] = axis->GetBinUpEdge(i);
   }
 
-  TGraph intVsXGraph(n, x, histIntegral);
+  TGraph intVsXGraph(n+1, x, histIntegral);
   intVsXGraph.SetBit(TGraph::kIsSortedX);
 
-  TGraph xVsIntGraph(n, histIntegral, x);
+  TGraph xVsIntGraph(n+1, histIntegral, x);
   xVsIntGraph.SetBit(TGraph::kIsSortedX);
 
   double intLo = intVsXGraph.Eval(xLo);
@@ -42,35 +50,21 @@ void BordersFinder::FindBorders() {
   auto cX = [=](double x) { return 100. / norm * (intVsXGraph.Eval(x) - intVsXGraph.Eval(xLo)); };
   auto xC = [=](double c) { return xVsIntGraph.Eval((c / 100.) * norm + intLo); };
 
-  for (auto cc : ranges_) {
-    double xx = isSpectator_ ? xC(cc) : xC(100 - cc);
-    cout << cc << "%"
-         << ", border:" << xx << endl;
-    borders_.push_back(xx);
-  }
-
-  /*
-    uint iSlice{0};
-    long int entriesCurrent{0};
-    
-    for (int iBin=1; iBin<=histo_.GetNbinsX() && iSlice<ranges_.size() ; ++iBin)
-    {
-        const double step = isSpectator_ ? ranges_.at(iSlice) : 100. - ranges_.at(iSlice);
-        const long int entriesNeeeded = step/100. * norm_;
-        entriesCurrent += histo_.GetBinContent(iBin);
-        
-        if (entriesCurrent >= entriesNeeeded)
-        {
-            const double ratio = histo_.GetBinContent(iBin)>0 ? (entriesCurrent - entriesNeeeded) / histo_.GetBinContent(iBin) : 0;
-            const double border = histo_.GetBinLowEdge(iBin) + histo_.GetBinWidth(iBin) * ratio;
-            
-            borders_.push_back(border);
-            
-            std::cout << ranges_.at(iSlice) << "%, border: " << border << std::endl;;
-            iSlice++;
-        }
+  if(is_ranges_predefined) {
+    for (auto cc : ranges_) {
+      double xx = isSpectator_ ? xC(cc) : xC(100 - cc);
+      cout << cc << "%"
+          << ", border:" << xx << endl;
+      borders_.push_back(xx);
     }
-*/
+  } else {
+    for(int i=0; i<=n; i++) {
+      borders_.push_back(x[i]);
+      auto cc = isSpectator_ ? histIntegral[i]*100 : (1 - histIntegral[i])*100;
+      ranges_.push_back(cc);
+      std::cout << cc << "%" << ", border:" << x[i] << "\n";
+    }
+  }
 }
 
 void BordersFinder::SaveBorders(const std::string& filename, const std::string& getter_name) {
@@ -78,7 +72,7 @@ void BordersFinder::SaveBorders(const std::string& filename, const std::string& 
 
   if (this->GetBorders().size() < 2) { return; }
 
-  std::unique_ptr<TFile> f{TFile::Open(filename.data(), "update")};
+  std::unique_ptr<TFile> f{TFile::Open(filename.data(), "recreate")};
 
   getter.SetBorders(this->GetBorders());
   getter.SetRanges(this->GetRanges());

--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -13,7 +13,7 @@ void BordersFinder::FindBorders() {
   using namespace std;
 
   bool is_ranges_predefined;
-  if(ranges_.size() > 1) {
+  if (ranges_.size() > 1) {
     is_ranges_predefined = true;
   } else if (ranges_.size() == 0) {
     is_ranges_predefined = false;
@@ -32,15 +32,15 @@ void BordersFinder::FindBorders() {
   int n = axis->GetNbins();
 
   double* histIntegral = histo_.GetIntegral();
-  double* x = new double[n+1];
+  double* x = new double[n + 1];
   for (int i = 0; i <= n; ++i) {
     x[i] = axis->GetBinUpEdge(i);
   }
 
-  TGraph intVsXGraph(n+1, x, histIntegral);
+  TGraph intVsXGraph(n + 1, x, histIntegral);
   intVsXGraph.SetBit(TGraph::kIsSortedX);
 
-  TGraph xVsIntGraph(n+1, histIntegral, x);
+  TGraph xVsIntGraph(n + 1, histIntegral, x);
   xVsIntGraph.SetBit(TGraph::kIsSortedX);
 
   double intLo = intVsXGraph.Eval(xLo);
@@ -50,19 +50,20 @@ void BordersFinder::FindBorders() {
   auto cX = [=](double x) { return 100. / norm * (intVsXGraph.Eval(x) - intVsXGraph.Eval(xLo)); };
   auto xC = [=](double c) { return xVsIntGraph.Eval((c / 100.) * norm + intLo); };
 
-  if(is_ranges_predefined) {
+  if (is_ranges_predefined) {
     for (auto cc : ranges_) {
       double xx = isSpectator_ ? xC(cc) : xC(100 - cc);
       cout << cc << "%"
-          << ", border:" << xx << endl;
+           << ", border:" << xx << endl;
       borders_.push_back(xx);
     }
   } else {
-    for(int i=0; i<=n; i++) {
+    for (int i = 0; i <= n; i++) {
       borders_.push_back(x[i]);
-      auto cc = isSpectator_ ? histIntegral[i]*100 : (1 - histIntegral[i])*100;
+      auto cc = isSpectator_ ? histIntegral[i] * 100 : (1 - histIntegral[i]) * 100;
       ranges_.push_back(cc);
-      std::cout << cc << "%" << ", border:" << x[i] << "\n";
+      std::cout << cc << "%"
+                << ", border:" << x[i] << "\n";
     }
   }
 }

--- a/src/Getter.cpp
+++ b/src/Getter.cpp
@@ -16,9 +16,12 @@ ClassImp(Centrality::Getter)
       return -1;
     }
 
-    //     std::cout << value << " " << ranges_.at(ibin-1) << "  " << ranges_.at(ibin) << std::endl;
+    auto lo = borders_.GetBinLowEdge(ibin);
+    auto hi = borders_.GetBinUpEdge(ibin);
+    auto left_weight = (hi-value) / (hi-lo);
+    auto right_weight = (value-lo) / (hi-lo);
 
-    const double centrality = 0.5 * (ranges_.at(ibin - 1) + ranges_.at(ibin));
+    const double centrality = left_weight * ranges_.at(ibin - 1) + right_weight * ranges_.at(ibin);
 
     return centrality;
   }

--- a/src/Getter.cpp
+++ b/src/Getter.cpp
@@ -18,8 +18,8 @@ ClassImp(Centrality::Getter)
 
     auto lo = borders_.GetBinLowEdge(ibin);
     auto hi = borders_.GetBinUpEdge(ibin);
-    auto left_weight = (hi-value) / (hi-lo);
-    auto right_weight = (value-lo) / (hi-lo);
+    auto left_weight = (hi - value) / (hi - lo);
+    auto right_weight = (value - lo) / (hi - lo);
 
     const double centrality = left_weight * ranges_.at(ibin - 1) + right_weight * ranges_.at(ibin);
 

--- a/tasks/main.cpp
+++ b/tasks/main.cpp
@@ -37,7 +37,8 @@ int main(int argc, char** argv) {
     Centrality::BordersFinder bf;
     bf.SetHisto(*histo);
     bf.SetRanges(20, 0, 100);// number of bins, min, max value
-    //   bf.SetRanges( {0,10,30,60,100} );  // centrality bins borders with array
+//     bf.SetRanges( {0, 2, 4, 6, 8, 10, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100} );  // centrality bins borders with array
+    // not to call SetRanges is also OK - then the ranging will be determined automatically according to input histo
     bf.IsSpectator(is_spectator);// true if impact parameter b correlated with estimator (spectators eneggy),
     // false - anticorrelated (multiplicity of produced particles)
 
@@ -51,7 +52,7 @@ int main(int argc, char** argv) {
 
     bf.SetHisto(*h1d);
     bf.SetRanges(20, 0, 100);// number of bins, min, max value
-    //   bf.SetRanges( {0,10,30,60,100} );  // centrality bins borders with array
+//     bf.SetRanges( {0,10,30,60,100} );  // centrality bins borders with array
     bf.IsSpectator(is_spectator);// true if impact parameter b correlated with estimator (spectators energy),
     // false - anticorrelated (multiplicity of produced particles)
 


### PR DESCRIPTION
- Added option not to set ranges in main.cpp executable. Then division into centrality classes will be performed according to the binning of the input histogram - this approach is with no losses information
- In Centrality::Getter::GetCentrality() a linear interpolation is used. It is better then take a middle of the bin.