### PR TITLE
Allow for sub-ranges in centrality slicing (required for simulatons)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ TH1D and TCanvas are also written into pdf-files produced during the executable 
 
 #### Slicing with a restricted impact parameter range
 
-If the simulated dataset does not cover the full minimum-bias range but only a restricted interval of impact parameters — for example *b* ∈ [2, 4] fm, which corresponds to roughly 10–20% centrality — the `SetRanges` call must reflect this by passing the known centrality limits as the `min` and `max` arguments and setting the fourth argument `fullRange` to `false`.
-This tells `BordersFinder` that the input histogram covers only this sub-range, so the integral normalization is scaled to the width of that window instead of assuming a 0–100% span.
+If the simulated dataset does not cover the full minimum-bias range but only a restricted interval of impact parameters — for example *b* ∈ [2, 4] fm, which corresponds to roughly 10–20% centrality — the `SetRanges` call must reflect this by passing the known centrality limits as the `min` and `max` arguments.
+The `BordersFinder` always derives its normalization from the specified range, so the integral is automatically scaled to the width of that window.
 
 In `tasks/main.cpp`, replace the standard call
 
@@ -85,7 +85,7 @@ In `tasks/main.cpp`, replace the standard call
 
 with
 
-    bf.SetRanges(4, 10, 20, false);  // 4 equal bins within the known 10–20% centrality window
+    bf.SetRanges(4, 10, 20);  // 4 equal bins within the known 10–20% centrality window
 
 and restrict the histogram to the corresponding estimator values with `SetLimits` if needed:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ TH1D and TCanvas are also written into pdf-files produced during the executable 
 (\*) When creating a histogram with discrete quantity, such as *M*, choose the bin edges in such a way that integer values are in the center of bin, but not at its edge (see "hMult" histogram in input/multiplicity_qa.urqmd.12agev.root).\
 (\*\*) Also there is a possibility to run a 2D slicing (i.e. to determine centrality classes simultaneously with two estimators - *M* and *E*<sub>PSD</sub>), however this procedure is not yet well-established and therefore deprecated.
 
+#### Slicing with a restricted impact parameter range
+
+If the simulated dataset does not cover the full minimum-bias range but only a restricted interval of impact parameters — for example *b* ∈ [2, 4] fm, which corresponds to roughly 10–20% centrality — the `SetRanges` call must reflect this by passing the known centrality limits as the `min` and `max` arguments and setting the fourth argument `fullRange` to `false`.
+This tells `BordersFinder` that the input histogram covers only this sub-range, so the integral normalization is scaled to the width of that window instead of assuming a 0–100% span.
+
+In `tasks/main.cpp`, replace the standard call
+
+    bf.SetRanges(20, 0, 100);
+
+with
+
+    bf.SetRanges(4, 10, 20, false);  // 4 equal bins within the known 10–20% centrality window
+
+and restrict the histogram to the corresponding estimator values with `SetLimits` if needed:
+
+    bf.SetLimits(xLo, xHi);  // histogram estimator values corresponding to b in [2, 4] fm
+
+The resulting `Getter` object will return centrality values in the range 10–20% and can be used in the filling step in the usual way.
+
 ### Filling
 
 Once slicing is preformed and the centrality_getter.root file is produced, filling the root-file containing reconstructed events can be done - each event will be assigned with estimated centrality percentage.

--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -9,6 +9,7 @@
 
 namespace Centrality {
 
+// ---------------------------------------------------------------------------------
 void BordersFinder::FindBorders() {
   using namespace std;
 
@@ -46,27 +47,38 @@ void BordersFinder::FindBorders() {
   double intHi = intVsXGraph.Eval(xHi);
   double norm = intHi - intLo;
 
-  auto cX = [=](double x) { return 100. / norm * (intVsXGraph.Eval(x) - intLo); };
-  auto xC = [=](double c) { return xVsIntGraph.Eval((c / 100.) * norm + intLo); };
+  // Check if full or only part of centrality range is used in input histogram
+  double cRangeInput = 100.;
+  double cStart = 100.;
+  double cOffset = 0.;
+  if (useFullRange_==false && is_ranges_predefined) {
+    cRangeInput = abs(ranges_.front() - ranges_.back());
+    cStart = isSpectator_ ? ranges_.back() : ranges_.front();
+    cOffset = isSpectator_ ? ranges_.front() : 0.;
+  }
+
+  auto cX = [=](double x) { return cRangeInput / norm * (intVsXGraph.Eval(x) - intLo); };
+  auto xC = [=](double c) { return xVsIntGraph.Eval((c / cRangeInput) * norm + intLo); };
 
   if (is_ranges_predefined) {
     for (auto cc : ranges_) {
-      double xx = isSpectator_ ? xC(cc) : xC(100 - cc);
-      cout << cc << "%"
-           << ", border:" << xx << endl;
+      double xx = isSpectator_ ? xC(cc - cOffset) : xC(cStart - cc);
+      std::cout << cc << "%" << ", border: " << xx << std::endl;
       borders_.push_back(xx);
     }
   } else {
     for (int i = 0; i <= n; i++) {
       borders_.push_back(x[i]);
-      auto cc = isSpectator_ ? cX(x[i]) : 100 - cX(x[i]);
+      auto cc = isSpectator_ ? cX(x[i]) : cStart - cX(x[i]);
       ranges_.push_back(cc);
-      std::cout << cc << "%"
-                << ", border:" << x[i] << "\n";
+      std::cout << cc << "%"  << ", border: " << x[i] << std::endl;
     }
   }
 }
+// ---------------------------------------------------------------------------------
 
+
+// ---------------------------------------------------------------------------------
 void BordersFinder::SaveBorders(const std::string& filename, const std::string& getter_name) {
   Getter getter;
 
@@ -88,5 +100,17 @@ void BordersFinder::SaveBorders(const std::string& filename, const std::string& 
 
   f->Close();
 }
+// ---------------------------------------------------------------------------------
+
+
+// ---------------------------------------------------------------------------------
+void BordersFinder::SetRanges(int n, double min, double max, bool fullRange) {
+  ranges_.clear();
+  for (int i = 0; i <= n; ++i) {
+    ranges_.push_back(min + i * (max - min) / n);
+  }
+  useFullRange_ = fullRange;
+}
+// ---------------------------------------------------------------------------------
 
 }// namespace Centrality

--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -47,11 +47,10 @@ void BordersFinder::FindBorders() {
   double intHi = intVsXGraph.Eval(xHi);
   double norm = intHi - intLo;
 
-  // Check if full or only part of centrality range is used in input histogram
   double cRangeInput = 100.;
   double cStart = 100.;
   double cOffset = 0.;
-  if (useFullRange_ == false && is_ranges_predefined) {
+  if (is_ranges_predefined) {
     cRangeInput = abs(ranges_.front() - ranges_.back());
     cStart = isSpectator_ ? ranges_.back() : ranges_.front();
     cOffset = isSpectator_ ? ranges_.front() : 0.;
@@ -104,12 +103,11 @@ void BordersFinder::SaveBorders(const std::string& filename, const std::string& 
 // ---------------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------------
-void BordersFinder::SetRanges(int n, double min, double max, bool fullRange) {
+void BordersFinder::SetRanges(int n, double min, double max) {
   ranges_.clear();
   for (int i = 0; i <= n; ++i) {
     ranges_.push_back(min + i * (max - min) / n);
   }
-  useFullRange_ = fullRange;
 }
 // ---------------------------------------------------------------------------------
 

--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -51,7 +51,7 @@ void BordersFinder::FindBorders() {
   double cRangeInput = 100.;
   double cStart = 100.;
   double cOffset = 0.;
-  if (useFullRange_==false && is_ranges_predefined) {
+  if (useFullRange_ == false && is_ranges_predefined) {
     cRangeInput = abs(ranges_.front() - ranges_.back());
     cStart = isSpectator_ ? ranges_.back() : ranges_.front();
     cOffset = isSpectator_ ? ranges_.front() : 0.;
@@ -71,12 +71,11 @@ void BordersFinder::FindBorders() {
       borders_.push_back(x[i]);
       auto cc = isSpectator_ ? cX(x[i]) : cStart - cX(x[i]);
       ranges_.push_back(cc);
-      std::cout << cc << "%"  << ", border: " << x[i] << std::endl;
+      std::cout << cc << "%" << ", border: " << x[i] << std::endl;
     }
   }
 }
 // ---------------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------------
 void BordersFinder::SaveBorders(const std::string& filename, const std::string& getter_name) {
@@ -101,7 +100,6 @@ void BordersFinder::SaveBorders(const std::string& filename, const std::string& 
   f->Close();
 }
 // ---------------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------------
 void BordersFinder::SetRanges(int n, double min, double max, bool fullRange) {

--- a/src/BordersFinder.cpp
+++ b/src/BordersFinder.cpp
@@ -63,7 +63,8 @@ void BordersFinder::FindBorders() {
   if (is_ranges_predefined) {
     for (auto cc : ranges_) {
       double xx = isSpectator_ ? xC(cc - cOffset) : xC(cStart - cc);
-      std::cout << cc << "%" << ", border: " << xx << std::endl;
+      std::cout << cc << "%"
+                << ", border: " << xx << std::endl;
       borders_.push_back(xx);
     }
   } else {
@@ -71,7 +72,8 @@ void BordersFinder::FindBorders() {
       borders_.push_back(x[i]);
       auto cc = isSpectator_ ? cX(x[i]) : cStart - cX(x[i]);
       ranges_.push_back(cc);
-      std::cout << cc << "%" << ", border: " << x[i] << std::endl;
+      std::cout << cc << "%"
+                << ", border: " << x[i] << std::endl;
     }
   }
 }

--- a/src/BordersFinder.hpp
+++ b/src/BordersFinder.hpp
@@ -23,13 +23,12 @@ class BordersFinder {
   void SetHisto(const TH1F& h) { histo_ = h; }
   TH1F& GetHisto() { return histo_; }// not const to use Draw etc
 
+  // Set ranges of centrality estimator by vector, e.g. {0., 25., 50., 75., 100.} centrality [%]
   void SetRanges(const std::vector<double>& ranges) { ranges_ = ranges; }
-  void SetRanges(int n, double min, double max) {
-    ranges_.clear();
-    for (int i = 0; i <= n; ++i) {
-      ranges_.push_back(min + i * (max - min) / n);
-    }
-  }
+
+  // Set ranges of centrality estimator, i.e. min, max centrality [%] + number of equal sized bins
+  void SetRanges(int n, double min, double max, bool fullRange = true);
+
   /**
   * To be used only in tests
   */
@@ -54,6 +53,7 @@ class BordersFinder {
   std::vector<double> borders_{};
 
   bool isSpectator_{false};
+  bool useFullRange_{true};
 
   bool applyLimits_{false};
   double xLo_{-1};

--- a/src/BordersFinder.hpp
+++ b/src/BordersFinder.hpp
@@ -27,7 +27,7 @@ class BordersFinder {
   void SetRanges(const std::vector<double>& ranges) { ranges_ = ranges; }
 
   // Set ranges of centrality estimator, i.e. min, max centrality [%] + number of equal sized bins
-  void SetRanges(int n, double min, double max, bool fullRange = true);
+  void SetRanges(int n, double min, double max);
 
   /**
   * To be used only in tests
@@ -53,7 +53,6 @@ class BordersFinder {
   std::vector<double> borders_{};
 
   bool isSpectator_{false};
-  bool useFullRange_{true};
 
   bool applyLimits_{false};
   double xLo_{-1};

--- a/src/BordersFinder.test.cpp
+++ b/src/BordersFinder.test.cpp
@@ -49,5 +49,56 @@ TEST(BordersFinder, Basics) {
   //  bf.SaveBorders(outfilename, "centr_getter_1d");
 }
 
+TEST(BordersFinder, NonSpectatorPartialRange) {
+  BordersFinder bf;
+
+  auto h1 = MakeHistoGaus();
+  bf.SetHisto(h1);
+  bf.SetRanges(4, 0, 20, false);
+  bf.IsSpectator(false);
+
+  bf.FindBorders();
+
+  auto ranges = bf.GetRanges();
+  auto borders = bf.GetBorders();
+
+  // Non-spectator reverses ranges_ in FindBorders, so they are stored high→low
+  EXPECT_FLOAT_EQ(ranges.at(0), 20);
+  EXPECT_FLOAT_EQ(ranges.at(1), 15);
+  EXPECT_FLOAT_EQ(ranges.at(2), 10);
+  EXPECT_FLOAT_EQ(ranges.at(3), 5);
+  EXPECT_FLOAT_EQ(ranges.at(4), 0);
+
+  // Non-spectator: higher x = more central = lower %; borders increase with decreasing centrality
+  EXPECT_LT(borders.at(0), borders.at(1));
+  EXPECT_LT(borders.at(1), borders.at(2));
+  EXPECT_LT(borders.at(2), borders.at(3));
+  EXPECT_LT(borders.at(3), borders.at(4));
+}
+
+TEST(BordersFinder, SpectatorPartialRange) {
+  BordersFinder bf;
+
+  auto h1 = MakeHistoGaus();
+  bf.SetHisto(h1);
+  bf.SetRanges(2, 10, 20, false);
+  bf.IsSpectator(true);
+
+  bf.FindBorders();
+
+  auto ranges = bf.GetRanges();
+  auto borders = bf.GetBorders();
+
+  EXPECT_FLOAT_EQ(ranges.at(0), 10);
+  EXPECT_FLOAT_EQ(ranges.at(1), 15);
+  EXPECT_FLOAT_EQ(ranges.at(2), 20);
+
+  // Spectator: higher x = more peripheral = higher %; borders increase with centrality %
+  EXPECT_LT(borders.at(0), borders.at(1));
+  EXPECT_LT(borders.at(1), borders.at(2));
+  // 10% border (most central in range) maps to median region; 20% (peripheral) maps further right
+  EXPECT_NEAR(borders.at(1), 0.0, 0.1);
+}
+
 }// namespace
 #endif

--- a/src/BordersFinder.test.cpp
+++ b/src/BordersFinder.test.cpp
@@ -54,7 +54,7 @@ TEST(BordersFinder, NonSpectatorPartialRange) {
 
   auto h1 = MakeHistoGaus();
   bf.SetHisto(h1);
-  bf.SetRanges(4, 0, 20, false);
+  bf.SetRanges(4, 0, 20);
   bf.IsSpectator(false);
 
   bf.FindBorders();
@@ -81,7 +81,7 @@ TEST(BordersFinder, SpectatorPartialRange) {
 
   auto h1 = MakeHistoGaus();
   bf.SetHisto(h1);
-  bf.SetRanges(2, 10, 20, false);
+  bf.SetRanges(2, 10, 20);
   bf.IsSpectator(true);
 
   bf.FindBorders();

--- a/tasks/fill_centrality.cpp
+++ b/tasks/fill_centrality.cpp
@@ -11,9 +11,8 @@ void fill_centrality(const std::string& filelist, const std::string& centrality_
   // The output file will be based on the input one with additional branches (and possibly with removed other branches)
   man->SetWriteMode(eBranchWriteMode::kCopyTree);
 
-  // Branches TrdTracks and RichRings will be removed from the output file, since they are irrelevant for the following analysis.
   // The branch RecEventHeader, which is an input branch, will be also removed, because a new one, based on it, will be created.
-  man->SetBranchesExclude({"TrdTracks", "RecEventHeader", "RichRings"});
+  man->SetBranchesExclude({"RecEventHeader"});
 
   // Initialize the Centrality::Getter prepared at the slicing step: 1-st argument - file, 2-nd argument - name of the getter.
   auto* task = new CentralityFiller(centrality_file, "centr_getter_1d");
@@ -24,30 +23,25 @@ void fill_centrality(const std::string& filelist, const std::string& centrality_
   // The name of an output EventHeader and name of field with centrality value
   task->SetOutput("AnaEventHeader", "centrality_tracks");
 
-  // Uncomment one of two following blocks:
-
   // ***** get centrality from multiplicity stored in the event header *****
-  task->SetInput("RecEventHeader", "M");
+  //   task->SetInput("RecEventHeader", "M");
   // ***** end of get centrality from multiplicity stored in the event header *****
 
-  //   // ***** get centrality from multiplicity of tracks stored in track detector passing set of cuts *****
+  // ***** get centrality from multiplicity of tracks stored in track detector passing set of cuts *****
   //   Note: the cuts which you use here must be the same which were used when creating an input histogram
   //   with a centrality-estimator quantity distribution for the slicing step
-  //
-  //   task->SetInput("VtxTracks");
-  //
-  //   AnalysisTree::SimpleCut vtx_chi2_track_cut = AnalysisTree::RangeCut("VtxTracks.vtx_chi2", 0, 3);
-  //   AnalysisTree::SimpleCut nhits_cut          = AnalysisTree::RangeCut("VtxTracks.nhits", 4, 100);
-  //   AnalysisTree::SimpleCut chi2_cut({"VtxTracks.chi2", "VtxTracks.ndf"},
-  //                                    [](std::vector<double> par) { return par[0] / par[1] < 3; });
-  //   AnalysisTree::SimpleCut eta_cut = AnalysisTree::RangeCut("VtxTracks.eta", 0.2, 6);
-  //
-  //   auto* vertex_tracks_cuts =
-  //     new AnalysisTree::Cuts("VtxTracks", {vtx_chi2_track_cut, nhits_cut, chi2_cut, eta_cut});
-  //
-  //   task -> SetTrackCuts(vertex_tracks_cuts);
-  //
-  //   // ***** end of get centrality from multiplicity of tracks stored in track detector passing set of cuts *****
+
+  task->SetInput("VtxTracks");
+
+  AnalysisTree::SimpleCut sc_vtx_chi2 = AnalysisTree::RangeCut("VtxTracks.vtx_chi2", 0, 3);
+  AnalysisTree::SimpleCut sc_nhits    = AnalysisTree::RangeCut("VtxTracks.nhits", 4, 100);
+  AnalysisTree::SimpleCut sc_chi2_ndf({{"VtxTracks.chi2"}, {"VtxTracks.ndf"}}, [](std::vector<double> par) { return par[0] / par[1] < 3; });
+  AnalysisTree::SimpleCut sc_eta      = AnalysisTree::RangeCut("VtxTracks.eta", 0.2, 6);
+
+  auto* tracks_cuts = new AnalysisTree::Cuts("VtxTracks", {sc_vtx_chi2, sc_nhits, sc_chi2_ndf, sc_eta});
+
+  task->SetTrackCuts(tracks_cuts);
+  // ***** end of get centrality from multiplicity of tracks stored in track detector passing set of cuts *****
 
   man->AddTask(task);
 
@@ -57,15 +51,15 @@ void fill_centrality(const std::string& filelist, const std::string& centrality_
 }
 
 int main(int argc, char** argv) {
-  if (argc <= 2) {
+  if (argc <= 3) {
     std::cout << "Not enough arguments! Please use:" << std::endl;
-    std::cout << "   ./fill_centrality filelist centrality_file" << std::endl;
+    std::cout << "   ./fill_centrality filelist centrality_getter outfile" << std::endl;
     return EXIT_FAILURE;
   }
 
   const std::string filelist = argv[1];
   const std::string centrality_file = argv[2];
-  const std::string output_file = "centrality.analysistree.root";
+  const std::string output_file = argv[3];
 
   fill_centrality(filelist, centrality_file, output_file);
   return EXIT_SUCCESS;

--- a/tasks/fill_centrality.cpp
+++ b/tasks/fill_centrality.cpp
@@ -34,9 +34,9 @@ void fill_centrality(const std::string& filelist, const std::string& centrality_
   task->SetInput("VtxTracks");
 
   AnalysisTree::SimpleCut sc_vtx_chi2 = AnalysisTree::RangeCut("VtxTracks.vtx_chi2", 0, 3);
-  AnalysisTree::SimpleCut sc_nhits    = AnalysisTree::RangeCut("VtxTracks.nhits", 4, 100);
+  AnalysisTree::SimpleCut sc_nhits = AnalysisTree::RangeCut("VtxTracks.nhits", 4, 100);
   AnalysisTree::SimpleCut sc_chi2_ndf({{"VtxTracks.chi2"}, {"VtxTracks.ndf"}}, [](std::vector<double> par) { return par[0] / par[1] < 3; });
-  AnalysisTree::SimpleCut sc_eta      = AnalysisTree::RangeCut("VtxTracks.eta", 0.2, 6);
+  AnalysisTree::SimpleCut sc_eta = AnalysisTree::RangeCut("VtxTracks.eta", 0.2, 6);
 
   auto* tracks_cuts = new AnalysisTree::Cuts("VtxTracks", {sc_vtx_chi2, sc_nhits, sc_chi2_ndf, sc_eta});
 

--- a/tasks/main.cpp
+++ b/tasks/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
     // Optionally set the limits of the 1D histogram, where to define centrality
     // e.g. if you need to remove unphysics tails of the esimator-quantity distribution
     // uncomment the next line
-    bf.SetLimits(0,500);
+    // bf.SetLimits(0,500);
 
     // (optionally*) Define the ranges of centrality classes to be obtained
     // for ranges with equivalent widths use the next line, for different widths - the line after the next

--- a/tasks/main.cpp
+++ b/tasks/main.cpp
@@ -42,11 +42,12 @@ int main(int argc, char** argv) {
     // Optionally set the limits of the 1D histogram, where to define centrality
     // e.g. if you need to remove unphysics tails of the esimator-quantity distribution
     // uncomment the next line
-    // bf.SetLimits(15, 80);
+    bf.SetLimits(0,500);
 
     // (optionally*) Define the ranges of centrality classes to be obtained
     // for ranges with equivalent widths use the next line, for different widths - the line after the next
     bf.SetRanges(20, 0, 100);// number of bins, min, max value
+			     // optional parameter: only centrality sub-range (false) or default full range (true) 
     // bf.SetRanges( {0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 100} );  // array
 
     // (*)It is also possible no to pre-define the centrality classes ranges -

--- a/tasks/main.cpp
+++ b/tasks/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     // (optionally*) Define the ranges of centrality classes to be obtained
     // for ranges with equivalent widths use the next line, for different widths - the line after the next
     bf.SetRanges(20, 0, 100);// number of bins, min, max value
-			     // optional parameter: only centrality sub-range (false) or default full range (true) 
+                             // optional parameter: only centrality sub-range (false) or default full range (true)
     // bf.SetRanges( {0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 100} );  // array
 
     // (*)It is also possible no to pre-define the centrality classes ranges -

--- a/tasks/main.cpp
+++ b/tasks/main.cpp
@@ -47,7 +47,6 @@ int main(int argc, char** argv) {
     // (optionally*) Define the ranges of centrality classes to be obtained
     // for ranges with equivalent widths use the next line, for different widths - the line after the next
     bf.SetRanges(20, 0, 100);// number of bins, min, max value
-                             // optional parameter: only centrality sub-range (false) or default full range (true)
     // bf.SetRanges( {0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 100} );  // array
 
     // (*)It is also possible no to pre-define the centrality classes ranges -


### PR DESCRIPTION
In simulation when a restricted impact parameter range is used, the centrality slicing should take into account, that only part of the distribution is present such that it does not slice 0-100% centrality always (as before), but allows for 10-20% with user-defined binning.